### PR TITLE
add build option to use boost.locale instead of std::codecvt to compile on GCC < 5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,23 @@
 cmake_minimum_required(VERSION 2.8)
 project(jamspell)
 
+option(USE_BOOST_CONVERT "use Boost.Locale instead of std::codecvt for string conversion" OFF)
+
 set(CMAKE_CXX_FLAGS "-std=c++11 -fPIC -g")
 
 find_package(GTest)
 
 link_directories(${PROJECT_BINARY_DIR}/jamspell)
 include_directories(${CMAKE_SOURCE_DIR})
+
+# find Boost if necessary
+if(USE_BOOST_CONVERT)
+    set(Boost_USE_STATIC_LIBS ON)
+    set(Boost_USE_MULTITHREADED ON)
+    find_package(Boost REQUIRED)
+    message(STATUS "Using Boost string convert: Enabled")
+    add_definitions(-DUSE_BOOST_CONVERT)
+endif()
 
 add_subdirectory(jamspell)
 add_subdirectory(main)

--- a/jamspell/CMakeLists.txt
+++ b/jamspell/CMakeLists.txt
@@ -1,3 +1,8 @@
 
 add_library(jamspell_lib spell_corrector.cpp lang_model.cpp utils.cpp perfect_hash.cpp bloom_filter)
 target_link_libraries(jamspell_lib phf cityhash)
+
+if(Boost_FOUND)
+    include_directories(${Boost_INCLUDE_DIRS})
+    target_link_libraries(jamspell_lib ${Boost_LIBRARIES})
+endif()

--- a/jamspell/utils.cpp
+++ b/jamspell/utils.cpp
@@ -1,11 +1,16 @@
 #include <fstream>
 #include <sstream>
-#include <codecvt>
 #include <chrono>
 #include <cassert>
 #include <iostream>
 #include <cassert>
 #include <algorithm>
+
+#ifdef USE_BOOST_CONVERT
+    #include <boost/locale/encoding_utf.hpp>
+#else
+    #include <codecvt>
+#endif
 
 #include "utils.hpp"
 
@@ -99,14 +104,24 @@ const std::unordered_set<wchar_t>& TTokenizer::GetAlphabet() const {
 }
 
 std::wstring UTF8ToWide(const std::string& text) {
+#ifdef USE_BOOST_CONVERT
+    using boost::locale::conv::utf_to_utf;
+    return utf_to_utf<wchar_t>(text.c_str(), text.c_str() + text.size());
+#else
     std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-    return converter.from_bytes(text);;
+    return converter.from_bytes(text);
+#endif
 }
 
 std::string WideToUTF8(const std::wstring& text) {
+#ifdef USE_BOOST_CONVERT
+    using boost::locale::conv::utf_to_utf;
+    return utf_to_utf<char>(text.c_str(), text.c_str() + text.size());
+#else
     using convert_type = std::codecvt_utf8<wchar_t>;
     std::wstring_convert<convert_type, wchar_t> converter;
     return converter.to_bytes(text);
+#endif
 }
 
 uint64_t GetCurrentTimeMs() {


### PR DESCRIPTION
Hey, here is workaround for https://github.com/bakwc/JamSpell/issues/12
Although it looks like a boilerplate of cmake for a small regression ^)
