### PR TITLE
Fix typo penaly -> penalty

### DIFF
--- a/jamspell/spell_corrector.cpp
+++ b/jamspell/spell_corrector.cpp
@@ -245,8 +245,8 @@ std::wstring TSpellCorrector::FixFragmentNormalized(const std::wstring& text) co
     return result;
 }
 
-void TSpellCorrector::SetPenalty(double knownWordsPenaly, double unknownWordsPenalty) {
-    KnownWordsPenalty = knownWordsPenaly;
+void TSpellCorrector::SetPenalty(double knownWordsPenalty, double unknownWordsPenalty) {
+    KnownWordsPenalty = knownWordsPenalty;
     UnknownWordsPenalty = unknownWordsPenalty;
 }
 

--- a/jamspell/spell_corrector.hpp
+++ b/jamspell/spell_corrector.hpp
@@ -16,7 +16,7 @@ public:
     std::vector<std::wstring> GetCandidates(const std::vector<std::wstring>& sentence, size_t position) const;
     std::wstring FixFragment(const std::wstring& text) const;
     std::wstring FixFragmentNormalized(const std::wstring& text) const;
-    void SetPenalty(double knownWordsPenaly, double unknownWordsPenalty);
+    void SetPenalty(double knownWordsPenalty, double unknownWordsPenalty);
     void SetMaxCandiatesToCheck(size_t maxCandidatesToCheck);
     const NJamSpell::TLangModel& GetLangModel() const;
 private:


### PR DESCRIPTION
The signature for SetPenalty contained a misspelt parameter name.