### PR TITLE
Fix typos

### DIFF
--- a/evaluate/generate_dataset.py
+++ b/evaluate/generate_dataset.py
@@ -174,7 +174,7 @@ def processSentences(sentences, outFile):
 
 
 def main():
-    parser = argparse.ArgumentParser(description='datset generator')
+    parser = argparse.ArgumentParser(description='dataset generator')
     parser.add_argument('out_file', type=str, help='will be created out_file_train and out_file_test')
     parser.add_argument('-lz', '--leipzig', type=str, help='path to file or dir with Leipzig Corpora files')
     parser.add_argument('-fb2', '--fb2', type=str, help='path to file or dir with files in FB2 format')

--- a/jamspell/spell_corrector.cpp
+++ b/jamspell/spell_corrector.cpp
@@ -148,7 +148,7 @@ TWords TSpellCorrector::GetCandidatesRaw(const TWords& sentence, size_t position
 }
 
 void TSpellCorrector::FilterCandidatesByFrequency(std::unordered_set<TWord, TWordHashPtr>& uniqueCandidates, TWord origWord) const {
-    if (uniqueCandidates.size() <= MaxCandiatesToCheck) {
+    if (uniqueCandidates.size() <= MaxCandidatesToCheck) {
         return;
     }
 
@@ -163,7 +163,7 @@ void TSpellCorrector::FilterCandidatesByFrequency(std::unordered_set<TWord, TWor
         return a.first > b.first;
     });
 
-    for (size_t i = 0; i < MaxCandiatesToCheck; ++ i) {
+    for (size_t i = 0; i < MaxCandidatesToCheck; ++ i) {
         uniqueCandidates.insert(candidateCounts[i].second);
     }
     uniqueCandidates.insert(origWord);
@@ -273,8 +273,8 @@ void TSpellCorrector::SetPenalty(double knownWordsPenalty, double unknownWordsPe
     UnknownWordsPenalty = unknownWordsPenalty;
 }
 
-void TSpellCorrector::SetMaxCandiatesToCheck(size_t maxCandidatesToCheck) {
-    MaxCandiatesToCheck = maxCandidatesToCheck;
+void TSpellCorrector::SetMaxCandidatesToCheck(size_t maxCandidatesToCheck) {
+    MaxCandidatesToCheck = maxCandidatesToCheck;
 }
 
 const TLangModel& TSpellCorrector::GetLangModel() const {

--- a/jamspell/spell_corrector.hpp
+++ b/jamspell/spell_corrector.hpp
@@ -20,7 +20,7 @@ public:
     std::wstring FixFragment(const std::wstring& text) const;
     std::wstring FixFragmentNormalized(const std::wstring& text) const;
     void SetPenalty(double knownWordsPenalty, double unknownWordsPenalty);
-    void SetMaxCandiatesToCheck(size_t maxCandidatesToCheck);
+    void SetMaxCandidatesToCheck(size_t maxCandidatesToCheck);
     const NJamSpell::TLangModel& GetLangModel() const;
 private:
     void FilterCandidatesByFrequency(std::unordered_set<NJamSpell::TWord, NJamSpell::TWordHashPtr>& uniqueCandidates, NJamSpell::TWord origWord) const;
@@ -37,7 +37,7 @@ private:
     std::unique_ptr<TBloomFilter> Deletes2;
     double KnownWordsPenalty = 20.0;
     double UnknownWordsPenalty = 5.0;
-    size_t MaxCandiatesToCheck = 14;
+    size_t MaxCandidatesToCheck = 14;
 };
 
 

--- a/tests/test_perfect_hash.cpp
+++ b/tests/test_perfect_hash.cpp
@@ -16,13 +16,13 @@ TEST(PerfetHashTest, basicFlow) {
     ph.Init(keys);
 
     ASSERT_TRUE(ph.BucketsNumber() < uint32_t(2.0 * keys.size()));
-    std::set<size_t> backetsUsed;
+    std::set<size_t> bucketsUsed;
 
     for (auto&& s: keys) {
-        backetsUsed.insert(ph.Hash(s));
+        bucketsUsed.insert(ph.Hash(s));
     }
 
-    ASSERT_EQ(keys.size(), backetsUsed.size());
+    ASSERT_EQ(keys.size(), bucketsUsed.size());
 
     std::string serialized;
     {
@@ -38,9 +38,9 @@ TEST(PerfetHashTest, basicFlow) {
         ph2.Load(in);
     }
 
-    backetsUsed.clear();
+    bucketsUsed.clear();
     for (auto&& s: keys) {
-        backetsUsed.insert(ph2.Hash(s));
+        bucketsUsed.insert(ph2.Hash(s));
     }
-    ASSERT_EQ(keys.size(), backetsUsed.size());
+    ASSERT_EQ(keys.size(), bucketsUsed.size());
 }


### PR DESCRIPTION
Found some misspellings.
Tool used: `typos`
The `contrib/` directory contains many more typos.

@bakwc Do you run JamSpell on JamSpell itself?
