### PR TITLE
Fix missing cstdint dependency

### DIFF
--- a/contrib/handypack/handypack.hpp
+++ b/contrib/handypack/handypack.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <list>


### PR DESCRIPTION
Small fix for missing include according to compilator suggestion. Without it compilation fails for me on two linux machines.